### PR TITLE
feat(tot-admin): add modern_country field

### DIFF
--- a/client-ardhianzy/src/features/admin/pages/AdminAddToTPage.tsx
+++ b/client-ardhianzy/src/features/admin/pages/AdminAddToTPage.tsx
@@ -11,6 +11,7 @@ type AdminToTForm = {
   geoorigin: string;
   detailLocation: string;
   years: string;
+  modernCountry: string;
   metaTitle: string;
   metaDescription: string;
   keywords: string;
@@ -34,6 +35,7 @@ const AdminAddToTPage: React.FC = () => {
     geoorigin: "",
     detailLocation: "",
     years: "",
+    modernCountry: "",
     metaTitle: "",
     metaDescription: "",
     keywords: "",
@@ -92,6 +94,8 @@ const AdminAddToTPage: React.FC = () => {
       if (form.detailLocation)
         fd.append("detail_location", form.detailLocation);
       if (form.years) fd.append("years", form.years);
+      if (form.modernCountry)
+        fd.append("modern_country", form.modernCountry);
       if (form.metaTitle) fd.append("meta_title", form.metaTitle);
       if (form.metaDescription)
         fd.append("meta_description", form.metaDescription);
@@ -203,22 +207,36 @@ const AdminAddToTPage: React.FC = () => {
                 placeholder="Misal: Amsterdam, Netherlands"
               />
             </div>
-          </div>
-
-          <div className="flex flex-col gap-2 max-w-xs">
-            <label className="text-xs text-neutral-400 tracking-[0.15em]">
-              YEARS (PERIODE)
-            </label>
-            <input
-              type="text"
-              className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
-                         focus:border-white"
-              value={form.years}
-              onChange={(e) =>
-                updateField("years", e.target.value)
-              }
-              placeholder="Misal: 1632–1677"
-            />
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-neutral-400 tracking-[0.15em]">
+                MODERN COUNTRY
+              </label>
+              <input
+                type="text"
+                className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
+                           focus:border-white"
+                value={form.modernCountry}
+                onChange={(e) =>
+                  updateField("modernCountry", e.target.value)
+                }
+                placeholder="Misal: Netherlands, France, Indonesia"
+              />
+            </div>
+            <div className="flex flex-col gap-2 max-w-xs">
+              <label className="text-xs text-neutral-400 tracking-[0.15em]">
+                YEARS (PERIODE)
+              </label>
+              <input
+                type="text"
+                className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
+                          focus:border-white"
+                value={form.years}
+                onChange={(e) =>
+                  updateField("years", e.target.value)
+                }
+                placeholder="Misal: 1632–1677"
+              />
+            </div>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
@@ -382,6 +400,11 @@ const AdminAddToTPage: React.FC = () => {
               {form.detailLocation && (
                 <span className="px-2 py-1 rounded-full border border-zinc-700">
                   Lokasi: {form.detailLocation}
+                </span>
+              )}
+              {form.modernCountry && (
+                <span className="px-2 py-1 rounded-full border border-zinc-700">
+                  Modern Country: {form.modernCountry}
                 </span>
               )}
               {form.years && (

--- a/client-ardhianzy/src/features/admin/pages/AdminEditToTPage.tsx
+++ b/client-ardhianzy/src/features/admin/pages/AdminEditToTPage.tsx
@@ -15,6 +15,7 @@ type AdminToTForm = {
   geoorigin: string;
   detailLocation: string;
   years: string;
+  modernCountry: string;
   metaTitle: string;
   metaDescription: string;
   keywords: string;
@@ -67,6 +68,7 @@ const AdminEditToTPage: React.FC = () => {
           geoorigin: raw.geoorigin ?? "",
           detailLocation: raw.detail_location ?? "",
           years: raw.years ?? "",
+          modernCountry: raw.modern_country ?? "",
           metaTitle: raw.meta_title ?? "",
           metaDescription: normalizeBackendHtml(
             raw.meta_description ?? ""
@@ -130,6 +132,8 @@ const AdminEditToTPage: React.FC = () => {
       if (form.detailLocation)
         fd.append("detail_location", form.detailLocation);
       if (form.years) fd.append("years", form.years);
+      if (form.modernCountry)
+        fd.append("modern_country", form.modernCountry);
       if (form.metaTitle) fd.append("meta_title", form.metaTitle);
       if (form.metaDescription)
         fd.append("meta_description", form.metaDescription);
@@ -269,21 +273,34 @@ const AdminEditToTPage: React.FC = () => {
                 }
               />
             </div>
-          </div>
-
-          <div className="flex flex-col gap-2 max-w-xs">
-            <label className="text-xs text-neutral-400 tracking-[0.15em]">
-              YEARS (PERIODE)
-            </label>
-            <input
-              type="text"
-              className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
-                         focus:border-white"
-              value={form.years}
-              onChange={(e) =>
-                updateField("years", e.target.value)
-              }
-            />
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-neutral-400 tracking-[0.15em]">
+                MODERN COUNTRY
+              </label>
+              <input
+                type="text"
+                className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
+                           focus:border-white"
+                value={form.modernCountry}
+                onChange={(e) =>
+                  updateField("modernCountry", e.target.value)
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-2 max-w-xs">
+              <label className="text-xs text-neutral-400 tracking-[0.15em]">
+                YEARS (PERIODE)
+              </label>
+              <input
+                type="text"
+                className="bg-black border border-zinc-700 rounded-xl px-3 py-2 text-sm outline-none
+                          focus:border-white"
+                value={form.years}
+                onChange={(e) =>
+                  updateField("years", e.target.value)
+                }
+              />
+            </div>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
@@ -435,6 +452,11 @@ const AdminEditToTPage: React.FC = () => {
               {form.detailLocation && (
                 <span className="px-2 py-1 rounded-full border border-zinc-700">
                   Lokasi: {form.detailLocation}
+                </span>
+              )}
+              {form.modernCountry && (
+                <span className="px-2 py-1 rounded-full border border-zinc-700">
+                  Modern Country: {form.modernCountry}
                 </span>
               )}
               {form.years && (

--- a/client-ardhianzy/src/features/admin/pages/AdminToTPage.tsx
+++ b/client-ardhianzy/src/features/admin/pages/AdminToTPage.tsx
@@ -73,6 +73,7 @@ const AdminToTPage: React.FC = () => {
       const origin = (t.geoorigin ?? "").toLowerCase();
       const location = (t.detail_location ?? "").toLowerCase();
       const years = (t.years ?? "").toLowerCase();
+      const modernCountry = (t.modern_country ?? "").toLowerCase();
       const slug = (t.slug ?? "").toLowerCase();
       const metaTitle = (t.meta_title ?? "").toLowerCase();
       const metaDescription = (t.meta_description ?? "").toLowerCase();
@@ -83,6 +84,7 @@ const AdminToTPage: React.FC = () => {
         origin.includes(q) ||
         location.includes(q) ||
         years.includes(q) ||
+        modernCountry.includes(q) ||
         slug.includes(q) ||
         metaTitle.includes(q) ||
         metaDescription.includes(q);
@@ -244,6 +246,11 @@ const AdminToTPage: React.FC = () => {
                           <div className="text-[11px] text-neutral-500 truncate max-w-[150px]">
                             {t.detail_location ?? ""}
                           </div>
+                          {t.modern_country && (
+                            <div className="text-[11px] text-neutral-400 truncate max-w-[150px]">
+                              {t.modern_country}
+                            </div>
+                          )}
                         </td>
                         <td className="px-4 py-3 align-top text-center text-xs text-neutral-300">
                           {t.years ?? "-"}
@@ -362,6 +369,11 @@ const AdminToTPage: React.FC = () => {
                           Lokasi: {t.detail_location}
                         </span>
                       )}
+                      {t.modern_country && (
+                        <span className="px-2 py-1 rounded-full border border-zinc-700">
+                          Modern Country: {t.modern_country}
+                        </span>
+                      )}
                       {t.years && (
                         <span className="px-2 py-1 rounded-full border border-zinc-700">
                           Years: {t.years}
@@ -404,6 +416,14 @@ const AdminToTPage: React.FC = () => {
                             Detail location:
                           </span>{" "}
                           {t.detail_location}
+                        </p>
+                      )}
+                      {t.modern_country && (
+                        <p>
+                          <span className="font-medium">
+                            Modern country:
+                          </span>{" "}
+                          {t.modern_country}
                         </p>
                       )}
                       {t.years && (

--- a/client-ardhianzy/src/features/home/components/map/PhilosopherDetailCard.tsx
+++ b/client-ardhianzy/src/features/home/components/map/PhilosopherDetailCard.tsx
@@ -55,7 +55,7 @@ export default function PhilosopherDetailCard({ philosopher, onClose }: Props) {
 
   const hero = philosopher.cardImage || philosopher.hero || DEFAULT_HERO;
   const dateText = philosopher.fullDates || philosopher.years || "";
-  const locationText = [philosopher.geoorigin, philosopher.detail_location].filter(Boolean).join(", ");
+  const locationText = philosopher.detail_location || philosopher.geoorigin || "";
   const infoLine = [dateText, locationText].filter(Boolean).join(" | ");
 
   return (

--- a/client-ardhianzy/src/lib/content/types.ts
+++ b/client-ardhianzy/src/lib/content/types.ts
@@ -6,6 +6,7 @@ export type ToTDTO = {
   geoorigin?: string | null;
   detail_location?: string | null;
   years?: string | null;
+  modern_country?: string | null;
   slug?: string | null;
   meta_title?: string | null;
   meta_description?: string | null;

--- a/client-ardhianzy/vite.config.ts
+++ b/client-ardhianzy/vite.config.ts
@@ -9,9 +9,6 @@ const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  server: {
-    host: true
-  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
*summary**
add full support for the `modern_country` field in Timeline of Thought (ToT) admin and public views, and align geomap markers with the modern country location while keeping detailed location text in the UI.

**changes**

* extended ToT DTO and admin table preview to include `modern_country`.
* updated **Add / Edit ToT** admin forms to capture and submit the `modern_country` field.
* wired `modern_country` into the public ToT map flow so marker coordinates are resolved from the modern country, while `detail_location` remains the human-readable place shown in the detail card.